### PR TITLE
update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var factory = module.exports = function(opts, arr){
 	}
 	var reduce = [].concat(arr)
 	return from(opts, function(size, cb){
-		if(reduce.length<=0) return cb()
+		if(reduce.length<=0) return cb(null, null)
 		cb(null, reduce.shift())
 	})	
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/binocarlos/from2-array/issues"
   },
   "homepage": "https://github.com/binocarlos/from2-array",
-  "devDependencies": {
-    "tape": "^2.12.3",
-    "through2": "^0.4.1"
-  },
   "dependencies": {
-    "from2": "^1.2.0"
+    "from2": "^2.0.3"
+  },
+  "devDependencies": {
+    "tape": "^4.0.0",
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
[through2](https://github.com/rvagg/through2) is now v2.0.0 that uses Streams3. (through2 v0.4.x uses Streams2.) 
